### PR TITLE
issue/9 Replicable ids for bookmarking

### DIFF
--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -97,7 +97,10 @@ export default class BranchingSet {
     nextModel.set('_branchAttempts', attemptIndex + 1);
     let wasAnyPartRestored = false;
     const cloned = nextModel.deepClone((clone, model) => {
-      clone.set('_isAvailable', true);
+      clone.set({
+        _id: `${model.get('_id')}_branching_${attemptIndex}`, // Replicable ids for bookmarking
+        _isAvailable: true
+      });
       // Remove tracking ids as these will change depending on the branches
       // Clone attempt states are stored on the original model in their order of occurance
       if (clone.has('_trackingId')) {


### PR DESCRIPTION
fixes #9 

### Fixed
* Cloned branching ids are now `[model._id]_branching_[modelAttemptIndex]` such that each attempt at each model id has a unique cloned id based upon its origin from branching and the number of times it was used in the branching, incremented from 0 upward.