### PR TITLE
issue/28 Guard against multiple calls to reset

### DIFF
--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -192,6 +192,8 @@ export default class BranchingSet {
   }
 
   async reset({ removeViews = false } = {}) {
+    if (this._isInReset) return;
+    this._isInReset = true;
     this.model.set('_requireCompletionOf', Number.POSITIVE_INFINITY);
     const parentView = Adapt.findViewByModelId(this.model.get('_id'));
     const childViews = parentView?.getChildViews();
@@ -216,6 +218,7 @@ export default class BranchingSet {
     Adapt.offlineStorage.set('b', branching);
     this.addFirstModel();
     await Adapt.parentView?.addChildren();
+    this._isInReset = false;
     return true;
   }
 


### PR DESCRIPTION
fixes #28 

### Fixed
* Sometimes an article's completion can flip rapidly between complete/incomplete with branching+assessment+trickle. Branching should only perform one reset at a time and wait for the page to render before continuing