### PR TITLE
New: Allow branching articles to cascade to other branching articles (fixes #37 fixes #33)

### DIFF
--- a/example.json
+++ b/example.json
@@ -14,7 +14,6 @@
 // blocks.json
 
   "_branching": {
-    "_isEnabled": true,
     "_containerId": "",
     "__comment": "leave _containerId blank to use the article _id",
     "_correct": "b-255",

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -140,7 +140,7 @@ export default class BranchingSet {
     }
 
     const lastChildConfig = lastChildModel.get('_branching');
-    if (!lastChildConfig || !lastChildConfig._isEnabled) return true;
+    if (!lastChildConfig) return true;
 
     // Branch from the last model's correctness, if configured
     const correctness = getCorrectness(lastChildModel);
@@ -254,7 +254,7 @@ export default class BranchingSet {
     return data.filter(model => {
       if (model.get('_isBranchClone')) return false;
       const config = model.get('_branching');
-      if (!config || config._isEnabled === false) return false;
+      if (!config) return false;
       return (config._containerId === containerId);
     });
   }
@@ -264,7 +264,7 @@ export default class BranchingSet {
     return data.filter(model => {
       if (!model.get('_isBranchClone')) return false;
       const config = model.get('_branching');
-      if (!config || config._isEnabled === false) return false;
+      if (!config) return false;
       return (config._containerId === containerId);
     });
   }

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -133,7 +133,7 @@ export default class BranchingSet {
     }
 
     const lastChildModel = branchedModels[branchedModels.length - 1];
-    const isLastIncomplete = !lastChildModel.get('_isComplete');
+    const isLastIncomplete = !lastChildModel.get('_isComplete') || !lastChildModel.get('_isOptional');
     if (isLastIncomplete && !isTheoretical) {
       return false;
     }
@@ -222,7 +222,7 @@ export default class BranchingSet {
     if (isAnyPartRestored) {
       // Make sure to explicitly set the block to complete if complete
       // This helps trickle setup locking correctly
-      const areAllDescendantsComplete = cloned.getAllDescendantModels(true).every(model => model.get('_isComplete'));
+      const areAllDescendantsComplete = cloned.getAllDescendantModels(true).every(model => model.get('_isComplete') || model.get('_isOptional'));
       if (areAllDescendantsComplete) {
         cloned.setCompletionStatus();
       }
@@ -280,7 +280,7 @@ export default class BranchingSet {
       // Excludes non-trackable extension components, like trickle buttons
       const areAllAvailableTrackableChildrenComplete = childModel.getChildren()
         .filter(model => model.get('_isAvailble') && model.get('_isTrackable'))
-        .every(model => model.get('_isComplete'));
+        .every(model => model.get('_isComplete') || model.get('_isOptional'));
       return areAllAvailableTrackableChildrenComplete;
     });
     return isEffectivelyComplete && this.isAtEnd;

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -5,6 +5,7 @@ import {
   getCorrectness
 } from './correctness';
 import offlineStorage from 'core/js/offlineStorage';
+import logging from 'core/js/logging';
 
 /** @typedef {import("core/js/models/adaptModel").default} AdaptModel */
 
@@ -164,7 +165,10 @@ export default class BranchingSet {
     if (nextModel === undefined) {
       // Set the start block of a different branching set
       const nextBranchingSet = Adapt.branching.getSubsetByModelId(nextId);
-      if (!nextBranchingSet) throw new Error(`Cannot branch to a model that isn't contained in a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
+      if (!nextBranchingSet) {
+        logging.error(`Cannot branch to a model that isn't contained in a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
+        return;
+      }
       if (!isTheoretical) nextBranchingSet.startId = nextId;
       // Mark as finished
       return true;

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -47,7 +47,7 @@ export default class BranchingSet {
 
   initialize() {
     this._wasInitialized = true;
-    this.preventParentCompletion();
+    this.disableParentCompletion();
     const wasRestored = this.restore();
     if (wasRestored) {
       // Check if the next model needs loading, this will happen if the previous
@@ -61,7 +61,7 @@ export default class BranchingSet {
     this.addFirstModel();
   }
 
-  preventParentCompletion() {
+  disableParentCompletion() {
     this.model.set({
       _canRequestChild: true,
       _requireCompletionOf: Number.POSITIVE_INFINITY
@@ -293,7 +293,7 @@ export default class BranchingSet {
   async reset({ removeViews = false } = {}) {
     if (this._isInReset || !this._wasInitialized) return;
     this._isInReset = true;
-    this.preventParentCompletion();
+    this.disableParentCompletion();
     const parentView = data.findViewByModelId(this.model.get('_id'));
     const childViews = parentView?.getChildViews();
     const branchedModels = this.branchedModels;

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -279,7 +279,7 @@ export default class BranchingSet {
       if (hasStandardCompletionCriteria) return false;
       // Excludes non-trackable extension components, like trickle buttons
       const areAllAvailableTrackableChildrenComplete = childModel.getChildren()
-        .filter(model => model.get('_isAvailble') && model.get('_isTrackable'))
+        .filter(model => model.get('_isAvailable') && model.get('_isTrackable'))
         .every(model => model.get('_isComplete') || model.get('_isOptional'));
       return areAllAvailableTrackableChildrenComplete;
     });

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -133,7 +133,7 @@ export default class BranchingSet {
     }
 
     const lastChildModel = branchedModels[branchedModels.length - 1];
-    const isLastIncomplete = !lastChildModel.get('_isComplete') || !lastChildModel.get('_isOptional');
+    const isLastIncomplete = !lastChildModel.get('_isComplete') && !lastChildModel.get('_isOptional');
     if (isLastIncomplete && !isTheoretical) {
       return false;
     }

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -164,7 +164,7 @@ export default class BranchingSet {
     if (nextModel === undefined) {
       // Set the start block of a different branching set
       const nextBranchingSet = Adapt.branching.getSubsetByModelId(nextId);
-      if (!nextBranchingSet) throw new Error(`Cannot branching to a model without a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
+      if (!nextBranchingSet) throw new Error(`Cannot branch to a model that isn't contained in a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
       if (!isTheoretical) nextBranchingSet.startId = nextId;
       // Mark as finished
       return true;

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -92,7 +92,7 @@ export default class BranchingSet {
     const config = this.model.get('_branching');
     if (!config._start) return;
     const isAtCorrectStart = (this.isAtStart && this.branchedModels[0]?.get('_branchOriginalModelId') === config._start);
-    if (isAtCorrectStart || !this.isAtStart || this.isAtEnd) return;
+    if (isAtCorrectStart || !this.isAtStart || this.isEffectivelyComplete) return;
     this.reset({ removeViews: true });
   }
 
@@ -283,7 +283,7 @@ export default class BranchingSet {
       if (hasStandardCompletionCriteria) return false;
       // Excludes non-trackable extension components, like trickle buttons
       const areAllAvailableTrackableChildrenComplete = childModel.getChildren()
-        .filter(model => model.get('_isAvailable') && model.get('_isTrackable'))
+        .filter(model => model.get('_isAvailable') && model.get('_isTrackable') !== false)
         .every(model => model.get('_isComplete') || model.get('_isOptional'));
       return areAllAvailableTrackableChildrenComplete;
     });

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -26,7 +26,7 @@ export default class BranchingSet {
     // Hide all branching container original children as only clones will be displayed
     children.forEach(child => {
       const config = child.get('_branching');
-      if (!config || !config._isEnabled) return;
+      if (!config) return;
       config._containerId = config._containerId || containerId;
       // Make direct children unavailable
       const isDirectChild = (child.getParent().get('_id') === containerId);
@@ -167,7 +167,7 @@ export default class BranchingSet {
       const nextBranchingSet = Adapt.branching.getSubsetByModelId(nextId);
       if (!nextBranchingSet) {
         logging.error(`Cannot branch to a model that isn't contained in a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
-        return;
+        return true;
       }
       if (!isTheoretical) nextBranchingSet.startId = nextId;
       // Mark as finished

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -13,6 +13,41 @@ export default class BranchingSet {
   constructor(options = {}) {
     /** @type {AdaptModel} */
     this.model = options.model;
+    this.setupModels();
+  }
+
+  setupModels() {
+    const containerId = this.model.get('_id');
+    const children = [
+      ...this.model.getChildren(),
+      ...data.filter(model => model.get('_branching')?._containerId === containerId)
+    ].filter(Boolean);
+    // Hide all branching container original children as only clones will be displayed
+    children.forEach(child => {
+      const config = child.get('_branching');
+      if (!config || !config._isEnabled) return;
+      config._containerId = config._containerId || containerId;
+      // Make direct children unavailable
+      const isDirectChild = (child.getParent().get('_id') === containerId);
+      if (isDirectChild) child.setOnChildren({ _isAvailable: false });
+      child.set({
+        _isBranchChild: true,
+        _isBranchClone: false
+      });
+      const descendants = [child].concat(child.getAllDescendantModels(true));
+      // Link all branch questions to their original ids ready for
+      // cloning and to facilitate save + restore
+      descendants.forEach(descendant => {
+        descendant.set('_branchOriginalModelId', descendant.get('_id'));
+        // Stop original items saving their own attemptStates as attemptStates are used to save/restore branching
+        if (descendant.isTypeGroup('component')) descendant.set('_shouldStoreAttempts', false);
+      });
+    });
+  }
+
+  initialize() {
+    this._wasInitialized = true;
+    this.preventParentCompletion();
     const wasRestored = this.restore();
     if (wasRestored) {
       // Check if the next model needs loading, this will happen if the previous
@@ -24,6 +59,40 @@ export default class BranchingSet {
       return;
     }
     this.addFirstModel();
+  }
+
+  preventParentCompletion() {
+    this.model.set({
+      _canRequestChild: true,
+      _requireCompletionOf: Number.POSITIVE_INFINITY
+    });
+  }
+
+  enableParentCompletion() {
+    this.model.set('_requireCompletionOf', -1);
+    // Synchronously check completion, this.model.checkCompletionStatus is async
+    Adapt.checkingCompletion();
+    this.model.checkCompletionStatusFor('_isComplete');
+    Adapt.checkingCompletion();
+    this.model.checkCompletionStatusFor('_isInteractionComplete');
+  }
+
+  get startId() {
+    return this.model.get('_branching')?._start;
+  }
+
+  set startId(modelId) {
+    const config = this.model.get('_branching');
+    if (!config) return;
+    config._start = modelId;
+  }
+
+  checkResetOnStartChange() {
+    const config = this.model.get('_branching');
+    if (!config._start) return;
+    const isAtCorrectStart = (this.isAtStart && this.branchedModels[0]?.get('_branchOriginalModelId') === config._start);
+    if (isAtCorrectStart || !this.isAtStart || this.isAtEnd) return;
+    this.reset({ removeViews: true });
   }
 
   restore() {
@@ -38,12 +107,7 @@ export default class BranchingSet {
       this.addNextModel(model, false, true, isLast);
     });
     if (this.isAtEnd) {
-      this.model.set('_requireCompletionOf', -1);
-      // Synchronously check completion, this.model.checkCompletionStatus is async
-      Adapt.checkingCompletion();
-      this.model.checkCompletionStatusFor('_isComplete');
-      Adapt.checkingCompletion();
-      this.model.checkCompletionStatusFor('_isInteractionComplete');
+      this.enableParentCompletion();
     }
     return true;
   }
@@ -82,15 +146,30 @@ export default class BranchingSet {
     const nextId = lastChildConfig._force || lastChildConfig[`_${correctness}`];
     if (!nextId) return true;
 
-    const isRelativeId = nextId.includes('@');
-    if (!isRelativeId) {
-      return brachingModels.find(model => model.get('_id') === nextId) || true;
+    function findNextModel(nextId) {
+      const isRelativeId = nextId.includes('@');
+      if (!isRelativeId) {
+        return brachingModels.find(model => model.get('_id') === nextId);
+      }
+      const originalLastChildModel = data.findById(lastChildModel.get('_branchOriginalModelId'));
+      const nextModel = originalLastChildModel.findRelativeModel(nextId);
+      const wasModelAlreadyUsed = nextModel.get('_isAvailable');
+      if (wasModelAlreadyUsed) return true;
+      return nextModel;
     }
 
-    const originalLastChildModel = data.findById(lastChildModel.get('_branchOriginalModelId'));
-    const nextModel = originalLastChildModel.findRelativeModel(nextId);
-    const wasModelAlreadyUsed = nextModel.get('_isAvailable');
-    if (wasModelAlreadyUsed) return true;
+    const nextModel = findNextModel(nextId);
+    // Mark as finished
+    if (nextModel === true) return true;
+    if (nextModel === undefined) {
+      // Set the start block of a different branching set
+      const nextBranchingSet = Adapt.branching.getSubsetByModelId(nextId);
+      if (!nextBranchingSet) throw new Error(`Cannot branching to a model without a branching set: ${nextId} from ${lastChildModel.get('_id')}`);
+      if (!isTheoretical) nextBranchingSet.startId = nextId;
+      // Mark as finished
+      return true;
+    }
+    // Provide the next model
     return nextModel;
   }
 
@@ -193,14 +272,28 @@ export default class BranchingSet {
     return (firstChild === lastChild);
   }
 
+  get isEffectivelyComplete() {
+    const isEffectivelyComplete = this.branchedModels.every(childModel => {
+      const requireCompletionOf = childModel.get('_requireCompletionOf');
+      const hasStandardCompletionCriteria = (requireCompletionOf !== -1);
+      if (hasStandardCompletionCriteria) return false;
+      // Excludes non-trackable extension components, like trickle buttons
+      const areAllAvailableTrackableChildrenComplete = childModel.getChildren()
+        .filter(model => model.get('_isAvailble') && model.get('_isTrackable'))
+        .every(model => model.get('_isComplete'));
+      return areAllAvailableTrackableChildrenComplete;
+    });
+    return isEffectivelyComplete && this.isAtEnd;
+  }
+
   get isAtEnd() {
-    return (this.getNextModel() === true);
+    return (this.getNextModel({ isTheoretical: true }) === true);
   }
 
   async reset({ removeViews = false } = {}) {
-    if (this._isInReset) return;
+    if (this._isInReset || !this._wasInitialized) return;
     this._isInReset = true;
-    this.model.set('_requireCompletionOf', Number.POSITIVE_INFINITY);
+    this.preventParentCompletion();
     const parentView = data.findViewByModelId(this.model.get('_id'));
     const childViews = parentView?.getChildViews();
     const branchedModels = this.branchedModels;
@@ -215,6 +308,7 @@ export default class BranchingSet {
       }
       data.remove(model);
     });
+    if (removeViews) parentView?.setChildViews(childViews);
     this.model.getChildren().remove(branchedModels);
     this.model.findDescendantModels('component').forEach(model => model.set('_attemptStates', []));
     const branching = offlineStorage.get('b') || {};

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -121,15 +121,15 @@ export default class BranchingSet {
 
   getNextModel({ isTheoretical = false } = {}) {
     const config = this.model.get('_branching');
-    const brachingModels = this.models;
+    const branchingModels = this.models;
     const branchedModels = this.branchedModels;
 
     const isBeforeStart = !branchedModels.length;
     if (isBeforeStart) {
       const hasStartId = Boolean(config._start);
       const firstModel = hasStartId ?
-        brachingModels.find(model => model.get('_id') === config._start) :
-        brachingModels[0];
+        branchingModels.find(model => model.get('_id') === config._start) :
+        branchingModels[0];
       return firstModel;
     }
 
@@ -150,7 +150,7 @@ export default class BranchingSet {
     function findNextModel(nextId) {
       const isRelativeId = nextId.includes('@');
       if (!isRelativeId) {
-        return brachingModels.find(model => model.get('_id') === nextId);
+        return branchingModels.find(model => model.get('_id') === nextId);
       }
       const originalLastChildModel = data.findById(lastChildModel.get('_branchOriginalModelId'));
       const nextModel = originalLastChildModel.findRelativeModel(nextId);

--- a/properties.schema
+++ b/properties.schema
@@ -47,12 +47,6 @@
               "type": "object",
               "legend": "Branching",
               "properties": {
-                "_isEnabled": {
-                  "type": "boolean",
-                  "default": true,
-                  "title": "Enable branching to/from this block",
-                  "inputType": "Checkbox"
-                },
                 "_containerId": {
                   "type": "string",
                   "default": "",


### PR DESCRIPTION
fixes #37
fixes #33 

It is now possible for a finishing branching article block from article-1 to set the starting block of branching article-2. This allows for cascading branching scenarios. Configured as normal.

### Fix
* ChildViews were not being removed properly on reset
* `_isOptional: true` support added

### New
* BranchingSet getter and setter `startId` added
* BranchingSet behaviour `checkResetOnStartChange` added and executed when the parent view attempts to render children
* BranchingSet `getNextModel` will now configure the `_start` property of any cascading sets if necessary

### Update
* `Adapt.branching.getSubsetByModelId` will now return the set if passed a child model
* Branching model setup behaviour is moved from the controller into the set at `setupModels`
* `isEffectivelyComplete` behaviour is moved from the controller into the set
* In order to allow sets to be available on initialisation for cascading `_start` ids, set initialisation is now detached from the constructor such that all of the sets are created and then initialised
* Common repeated code to set and unset `_requireCompletionOf` is now moved into `enableParentCompletion` and `disableParentCompletion`

refs https://github.com/adaptlearning/adapt-contrib-trickle/pull/169

