### PR TITLE
Fix: Added _start to example, readme and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_onChildren** (boolean):  If set to `true`, usually on an article, its children will be used for the branching scenario.
 
+>**\_start** (string):  Used only on an article, defines the starting block for the branching scenario. Leave blank to use the first block.
+
 >**\_containerId** (string):  To add a block to a alternative branching set, add the branching id here. Leave this blank to use the current parent.
 
 >**\_correct** (string):  When the mandatory questions contained are all correct and complete, this is the id of the next content block.

--- a/example.json
+++ b/example.json
@@ -8,7 +8,8 @@
   "_branching": {
     "_isEnabled": true,
     "_onChildren": true,
-    "_start": "b-250"
+    "_comment": "Leave _start blank to start on the first block in the article",
+    "_start": ""
   },
 
 // blocks.json

--- a/properties.schema
+++ b/properties.schema
@@ -37,6 +37,13 @@
                   "inputType": "Checkbox"
                 }
               }
+            },
+            "_start": {
+              "type": "string",
+              "default": "",
+              "title": "Start block id",
+              "inputType": "Text",
+              "help": "Leave blank to use the first block"
             }
           }
         },


### PR DESCRIPTION
fixes #39 

### Fix
* Add `_start` to readme, example.json and schema
