### PR TITLE
Update: Documentation improvements (fixes #57)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_containerId** (string):  To add a block to a alternative branching set, add the branching id here. Leave this blank to use the current parent.
 
->**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two options can be ignored. Leave blank to use the next block.
+>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored. Leave blank to use the next available block.
 
->**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next block.
+>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next available block.
 
->**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next block.
+>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next available block.
 
 >**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness.
 
@@ -49,11 +49,11 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_attempts** (number):  This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
 
->>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two options can be ignored. Leave blank to use the next block.
+>>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored. Leave blank to use the next available block.
 
->>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next block.
+>>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next available block.
 
->>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next block.
+>>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next available block.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add to *blocks.json*:
 ## Notes
 
 * All blocks that are part of a branching scenario should have a `_branching` object even if it is empty. For instance, the last block in a branching article can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In a branching article, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks.
-* [**Trickle**](https://github.com/adaptlearning/adapt-contrib-trickle) should not be disabled on any blocks that are part of a branching scenario. To visually disable Trickle on a branched block, you can modify other Trickle properties (e.g. disable the `_button` or disable `_autoScroll`).
+* When [**Trickle**](https://github.com/adaptlearning/adapt-contrib-trickle) is enabled on the branching article, no child blocks should disable Trickle. To visually disable Trickle on a branched block, you can modify other Trickle properties (e.g. disable the `_button` or disable `_autoScroll`).
 * You may use relative selectors like `@block+1` for the values of **\_correct**, **\_incorrect** and **\_partlyCorrect**. However, this can have unpredictable results when using block randomization in an assessment.
 * Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 * Multiple branching experiences can be used on the same page using multiple articles.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add to *blocks.json*:
 
 >**\_hasAttemptBands** (boolean): If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness. Use only when the block contains question component(s). Defaults to `false`.
 
->**\_useQuestionAttempts** (boolean): If set to `true`, **\_hasAttemptBands** will branch according to the previous completed attempts at this question, including when the question is shown multiple times in the branching sequence. When `false`, **\_hasAttemptBands** will branch according to the question's own `_attempts` value. Defaults to `false`.
+>**\_useQuestionAttempts** (boolean): If set to `true`, **\_hasAttemptBands** will branch according to all previous completed attempts at this question, including when the question is shown multiple times in the branching sequence. When `false`, **\_hasAttemptBands** will branch according to the question's own `_attempts` value. Defaults to `false`.
 
 >**\_attemptBands** (object array): Multiple items may be created. Each item represents the branching options for the appropriate range of attempts.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 * Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 
 ----------------------------
-**Framework versions:**  5.7+<br/>
+
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-trickle/graphs/contributors)<br/>
 **Accessibility support:** WAI AA<br/>
 **RTL support:** Yes<br/>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 ## Notes
 
-* All blocks that are part of a branching scenario need to have a `_branching` object, even if it's empty. For instance, a block can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In an article with branching enabled, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks
+* All blocks that are part of a branching scenario need to have a `_branching` object, even if it's empty. For instance, the last block in a branching article can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In a branching article, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks
 * You may use relative selectors like `@block+1` for the values of **\_correct**, **\_incorrect** and **\_partlyCorrect**. However, this can have unpredictable results when using block randomization in an assessment.
 * Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 * Multiple branching experiences can be used on the same page using multiple articles.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_start** (string):  Used only on an article, defines the starting block for the branching scenario. Leave blank to use the first block.
 
->**\_containerId** (string):  To add a block to a alternative branching set, add the branching id here. Leave this blank to use the current parent.
+>**\_containerId** (string):  To add a block to an alternative branching set, add the branching id here. Useful to pull in a block that lives outside of a branching article into that article's branching scenario. Leave blank to use the id of the current parent article.
 
 >**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
@@ -41,7 +41,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
 
->**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness.
+>**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness (or completion for presentation components).
 
 >**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question.
 
@@ -57,7 +57,7 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 ## Notes
 
-* All blocks that are part of a branching sequence need to have a `_branching` object, even if it's empty. For instance, a block can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own.
+* All blocks that are part of a branching scenario need to have a `_branching` object, even if it's empty. For instance, a block can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In an article with branching enabled, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks
 * You may use relative selectors like `@block+1` for the values of **\_correct**, **\_incorrect** and **\_partlyCorrect**. However, this can have unpredictable results when using block randomization in an assessment.
 * Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 * Multiple branching experiences can be used on the same page using multiple articles.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The **Branching** extension allows an article to contain a series of blocks whic
 
 ## Settings Overview
 
-A basic **Branching** configuration would be at the article (*articles.json*) level with branching block children (*blocks.json*). The **\_onChildren** attribute determines the container.
+A basic **Branching** configuration would be at the article (*articles.json*) level with branching block children (*blocks.json*).
 
 The attributes listed below are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-branching/blob/master/example.json).
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_start** (string):  Used only on an article, defines the starting block for the branching scenario. Leave blank to use the first block.
 
->**\_containerId** (string):  To add a block to an alternative branching set, add the branching id here. Useful to pull in a block that lives outside of a branching article into that article's branching scenario. Leave blank to use the id of the current parent article.
-
 >**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
 >**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add to *blocks.json*:
 
 >**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
 
->**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness (or completion for presentation components). Defaults to `false`.
+>**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness. Use only when the block contains question component(s). Defaults to `false`.
 
 >**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question. Otherwise, **\_hasAttemptBands** will branch according to attempts at the article's assessment. Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add to *articles.json*:
 
 >**\_isEnabled** (boolean):  Turns on and off the **Branching** extension for this article.
 
->**\_start** (string):  Used only on an article, defines the starting block for the branching scenario. Leave blank to use the first block.
+>**\_start** (string):  Defines the starting block for the branching scenario. Leave blank to use the first block.
 
 Add to *blocks.json*:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Branching** is an *extension* which is *not* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
 
-The **Branching** extension allows an article to contain a series of blocks which branch according to block correctness. Using **Branching**, a course author may create a dynamic experience based upon user responses.
+The **Branching** extension allows an article to contain a series of blocks which branch according to block correctness. It can also be used with blocks that contain presentation components (e.g. [Narrative](https://github.com/adaptlearning/adapt-contrib-narrative)), branching based on completeness instead. Using **Branching**, a course author may create a dynamic experience based upon user responses.
 
 ## Installation
 
@@ -19,7 +19,7 @@ The **Branching** extension allows an article to contain a series of blocks whic
 
 ## Settings Overview
 
-- A basic **Branching** configuration would be at the article (*articles.json*) level with branching block children (*blocks.json*). The **\_onChildren** attribute determines the container.
+A basic **Branching** configuration would be at the article (*articles.json*) level with branching block children (*blocks.json*). The **\_onChildren** attribute determines the container.
 
 The attributes listed below are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-branching/blob/master/example.json).
 
@@ -35,11 +35,11 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_containerId** (string):  To add a block to a alternative branching set, add the branching id here. Leave this blank to use the current parent.
 
->**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block.
+>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two options can be ignored. Leave blank to use the next block.
 
->**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
+>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next block.
 
->**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
+>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next block.
 
 >**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness.
 
@@ -49,21 +49,23 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_attempts** (number):  This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
 
->>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block.
+>>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two options can be ignored. Leave blank to use the next block.
 
->>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
+>>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next block.
 
->>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
+>>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next block.
 
 ## Notes
 
 * All blocks that are part of a branching sequence need to have a `_branching` object, even if it's empty. For instance, a block can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own.
+* You may use relative selectors like `@block+1` for the values of **\_correct**, **\_incorrect** and **\_partlyCorrect**. However, this can have unpredictable results when using block randomization in an assessment.
+* Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
+* Multiple branching experiences can be used on the same page using multiple articles.
 
 ## Limitations
 
 * This extension will not work with legacy versions of trickle <=4.  
 * This extension will not work with legacy versions of assessment <=4.  
-* Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_containerId** (string):  To add a block to a alternative branching set, add the branching id here. Leave this blank to use the current parent.
 
->**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored. Leave blank to use the next available block.
+>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
->**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next available block.
+>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
 
->**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next available block.
+>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
 
 >**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness.
 
@@ -49,11 +49,11 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >>**\_attempts** (number):  This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
 
->>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored. Leave blank to use the next available block.
+>>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
->>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block. Leave blank to use the next available block.
+>>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
 
->>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block. Leave blank to use the next available block.
+>>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -29,41 +29,41 @@ Add to *course.json*:
 
 **\_branching** (object): The branching object contains the following settings:
 
->**\_isEnabled** (boolean):  Turns on and off the **Branching** extension for the entire course.
+>**\_isEnabled** (boolean): Turns on and off the **Branching** extension for the entire course.
 
 Add to *articles.json*:
 
 **\_branching** (object): The branching object contains the following settings:
 
->**\_isEnabled** (boolean):  Turns on and off the **Branching** extension for this article.
+>**\_isEnabled** (boolean): Turns on and off the **Branching** extension for this article.
 
->**\_start** (string):  Defines the starting block for the branching scenario. Leave blank to use the first block.
+>**\_start** (string): Defines the starting block for the branching scenario. Leave blank to use the first block.
 
 Add to *blocks.json*:
 
 **\_branching** (object): The branching object contains the following settings:
 
->**\_isEnabled** (boolean):  Turns on and off the **Branching** extension where not required. Useful during course development.
+>**\_isEnabled** (boolean): Turns on and off the **Branching** extension where not required. Useful during course development.
 
->**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
+>**\_correct** (string): When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
->**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
+>**\_partlyCorrect** (string): When the questions contained are partly correct and complete, this is the id of the next content block.
 
->**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
+>**\_incorrect** (string): When the questions contained are all incorrect and complete, this is the id of the next content block.
 
->**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness. Use only when the block contains question component(s). Defaults to `false`.
+>**\_hasAttemptBands** (boolean): If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness. Use only when the block contains question component(s). Defaults to `false`.
 
->**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question, including when the question is shown multiple times in the branching sequence. When `false`, **\_hasAttemptBands** will branch according to the question's own `_attempts` value. Defaults to `false`.
+>**\_useQuestionAttempts** (boolean): If set to `true`, **\_hasAttemptBands** will branch according to the previous completed attempts at this question, including when the question is shown multiple times in the branching sequence. When `false`, **\_hasAttemptBands** will branch according to the question's own `_attempts` value. Defaults to `false`.
 
 >**\_attemptBands** (object array): Multiple items may be created. Each item represents the branching options for the appropriate range of attempts.
 
->>**\_attempts** (number):  This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
+>>**\_attempts** (number): This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
 
->>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block.
+>>**\_correct** (string): When the questions contained are all correct and complete, this is the id of the next content block.
 
->>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
+>>**\_partlyCorrect** (string): When the questions contained are partly correct and complete, this is the id of the next content block.
 
->>**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
+>>**\_incorrect** (string): When the questions contained are all incorrect and complete, this is the id of the next content block.
 
 ## Notes
 
@@ -74,8 +74,8 @@ Add to *blocks.json*:
 
 ## Limitations
 
-* This extension will not work with legacy versions of trickle <=4.  
-* This extension will not work with legacy versions of assessment <=4.  
+* This extension will not work with legacy versions of trickle <=4.
+* This extension will not work with legacy versions of assessment <=4.
 
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,25 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 ### Attributes
 
-**\_branching** (object): The Branching attributes group contains values for **\_isEnabled**, **\_onChildren**, **\_correct**, **\_partlyCorrect**, and **\_incorrect**.
+Add to *course.json*:
 
->**\_isEnabled** (boolean):  Turns on and off the **Branching** extension. Can be set in *course.json*, *articles.json* and *blocks.json* to disable **Branching** where not required. Also useful during course development.
+**\_branching** (object): The branching object contains the following settings:
 
->**\_onChildren** (boolean):  If set to `true`, usually on an article, its children will be used for the branching scenario.
+>**\_isEnabled** (boolean):  Turns on and off the **Branching** extension for the entire course.
+
+Add to *articles.json*:
+
+**\_branching** (object): The branching object contains the following settings:
+
+>**\_isEnabled** (boolean):  Turns on and off the **Branching** extension for this article.
 
 >**\_start** (string):  Used only on an article, defines the starting block for the branching scenario. Leave blank to use the first block.
+
+Add to *blocks.json*:
+
+**\_branching** (object): The branching object contains the following settings:
+
+>**\_isEnabled** (boolean):  Turns on and off the **Branching** extension where not required. Useful during course development.
 
 >**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
 
@@ -39,15 +51,15 @@ The attributes listed below are properly formatted as JSON in [*example.json*](h
 
 >**\_incorrect** (string):  When the questions contained are all incorrect and complete, this is the id of the next content block.
 
->**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness (or completion for presentation components).
+>**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness (or completion for presentation components). Defaults to `false`.
 
->**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question.
+>**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question. Otherwise, **\_hasAttemptBands** will branch according to attempts at the article's assessment. Defaults to `false`.
 
->**\_attemptBands** (object array): Multiple items may be created. Each item represents the branching options for the appropriate range of attempts. **\_attemptBands** contains values for **\_attempts**, **\_correct**, **\_partlyCorrect** and **\_incorrect**.
+>**\_attemptBands** (object array): Multiple items may be created. Each item represents the branching options for the appropriate range of attempts.
 
 >>**\_attempts** (number):  This numeric value represents the start of the range. The range continues to the next highest **\_attempts** of another band.
 
->>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block. Use this property for blocks that only contain presentation components as the other two correctness options can be ignored.
+>>**\_correct** (string):  When the questions contained are all correct and complete, this is the id of the next content block.
 
 >>**\_partlyCorrect** (string):  When the questions contained are partly correct and complete, this is the id of the next content block.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add to *blocks.json*:
 
 >**\_hasAttemptBands** (boolean):  If set to `true`, turns on the **\_attemptBands** behaviour, allowing branching to happen across both attempts and correctness. Otherwise, branching will happen only for correctness. Use only when the block contains question component(s). Defaults to `false`.
 
->**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question. Otherwise, **\_hasAttemptBands** will branch according to attempts at the article's assessment. Defaults to `false`.
+>**\_useQuestionAttempts** (boolean):  If set to `true`,  **\_hasAttemptBands** will branch according to the previous completed attempts at this question, including when the question is shown multiple times in the branching sequence. When `false`, **\_hasAttemptBands** will branch according to the question's own `_attempts` value. Defaults to `false`.
 
 >**\_attemptBands** (object array): Multiple items may be created. Each item represents the branching options for the appropriate range of attempts.
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ Add to *blocks.json*:
 
 ## Notes
 
-* All blocks that are part of a branching scenario need to have a `_branching` object, even if it's empty. For instance, the last block in a branching article can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In a branching article, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks
+* All blocks that are part of a branching scenario should have a `_branching` object even if it is empty. For instance, the last block in a branching article can simply use `"_branching": {}` if it should conditionally be shown but does not create any branches of its own. In a branching article, if a particular block does *not* have any `_branching` properties, it will be shown at top of the article, preceding all branching blocks.
+* [**Trickle**](https://github.com/adaptlearning/adapt-contrib-trickle) should not be disabled on any blocks that are part of a branching scenario. To visually disable Trickle on a branched block, you can modify other Trickle properties (e.g. disable the `_button` or disable `_autoScroll`).
 * You may use relative selectors like `@block+1` for the values of **\_correct**, **\_incorrect** and **\_partlyCorrect**. However, this can have unpredictable results when using block randomization in an assessment.
 * Spoor [`_shouldStoreAttempts`](https://github.com/adaptlearning/adapt-contrib-spoor#_shouldstoreattempts-boolean) should be set to true to retain the user selections across sessions
 * Multiple branching experiences can be used on the same page using multiple articles.
 
 ## Limitations
 
-* This extension will not work with legacy versions of trickle <=4.
-* This extension will not work with legacy versions of assessment <=4.
+* This extension will not work with legacy versions of Trickle <=4.
+* This extension will not work with legacy versions of Assessment <=4.
 
 ----------------------------
 

--- a/example.json
+++ b/example.json
@@ -6,7 +6,6 @@
 // articles.json
   "_branching": {
     "_isEnabled": true,
-    "_onChildren": true,
     "_comment": "Leave _start blank to start on the first block in the article",
     "_start": ""
   },

--- a/example.json
+++ b/example.json
@@ -13,8 +13,6 @@
 
 // blocks.json
   "_branching": {
-    "_containerId": "",
-    "__comment": "leave _containerId blank to use the article _id",
     "_correct": "b-255",
     "_partlyCorrect": "b-260",
     "_incorrect": "b-270"
@@ -22,8 +20,6 @@
 
 // blocks.json - When using attempt-based branching
   "_branching": {
-    "_containerId": "",
-    "__comment": "leave _containerId blank to use the article _id",
     "_hasAttemptBands": true,
     "_useQuestionAttempts": false,
     "_attemptBands": [

--- a/properties.schema
+++ b/properties.schema
@@ -59,7 +59,7 @@
                   "default": "",
                   "title": "Alternate branching container id",
                   "inputType": "Text",
-                  "help": "Leave blank to use the current article"
+                  "help": "Leave blank to use the current article id"
                 },
                 "_correct": {
                   "type": "string",
@@ -89,7 +89,7 @@
                   "title": "Has attempt bands",
                   "inputType": "Checkbox",
                   "validators": [],
-                  "help": "Controls whether this block will branch according to correctness and attempt or just correctness"
+                  "help": "When selected, this block will branch according to correctness and attempt rather than just correctness."
                 },
                 "_useQuestionAttempts": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -54,13 +54,6 @@
               "type": "object",
               "legend": "Branching",
               "properties": {
-                "_containerId": {
-                  "type": "string",
-                  "default": "",
-                  "title": "Alternate branching container id",
-                  "inputType": "Text",
-                  "help": "Leave blank to use the current article id"
-                },
                 "_correct": {
                   "type": "string",
                   "default": "",

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -16,7 +16,7 @@
             "_containerId": {
               "type": "string",
               "title": "Alternate branching container id",
-              "description": "Leave blank to use the current article",
+              "description": "Leave blank to use the current article id",
               "default": ""
             },
             "_correct": {
@@ -40,7 +40,7 @@
             "_hasAttemptBands": {
               "type": "boolean",
               "title": "Has attempt bands",
-              "description": "Controls whether this block will branch according to correctness and attempt or just correctness",
+              "description": "When selected, this block will branch according to correctness and attempt rather than just correctness.",
               "default": false
             },
             "_useQuestionAttempts": {

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -13,12 +13,6 @@
           "title": "Branching",
           "default": {},
           "properties": {
-            "_containerId": {
-              "type": "string",
-              "title": "Alternate branching container id",
-              "description": "Leave blank to use the current article id",
-              "default": ""
-            },
             "_correct": {
               "type": "string",
               "title": "Correct target",


### PR DESCRIPTION
Fixes #57 

### Fix
* Fix typo in _pull_request_template.md_

### Updates to _README.md_ and schemas
* Remove required framework version
* Remove `_containerId` as this was used for a very specific use case. The property still remains in the code to avoid breaking changes.
* Removed `_onChildren` property from documentation. It was already absent from the schemas. The property still remains in the code to avoid breaking changes.
* Add clarification for using branched blocks that contain only presentation components.
* Add note about using relative selectors
* Add note about using multiple branching articles on a page
* Add note about using Trickle on articles