### PR TITLE
Fix: Ensure user answers are correctly restored (fixes #56)

### DIFF
--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -224,10 +224,15 @@ export default class BranchingSet {
     if (isAnyPartRestored) {
       // Make sure to explicitly set the block to complete if complete
       // This helps trickle setup locking correctly
-      const areAllDescendantsComplete = cloned.getAllDescendantModels(true).every(model => model.get('_isComplete'));
+      const allDescendantsModels = cloned.getAllDescendantModels(true);
+      const areAllDescendantsComplete = allDescendantsModels.every(model => model.get('_isComplete'));
       if (areAllDescendantsComplete) {
         cloned.setCompletionStatus();
       }
+      // Try to restore user answers on all questions
+      allDescendantsModels
+        .filter(model => model.isTypeGroup('question'))
+        .forEach(model => model?.restoreUserAnswers?.());
     }
     if (shouldSave) {
       this.saveNextModel(nextModel);

--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -232,7 +232,7 @@ export default class BranchingSet {
       // Try to restore user answers on all questions
       allDescendantsModels
         .filter(model => model.isTypeGroup('question'))
-        .forEach(model => model?.restoreUserAnswers?.());
+        .forEach(model => model.restoreUserAnswers());
     }
     if (shouldSave) {
       this.saveNextModel(nextModel);


### PR DESCRIPTION
fixes #56 

### Fix
* Ensure `restoreUserAnswers` is called after cloned items are set up at `setUpItems` and before `adapt:initialise` where `restoreUserAnswers` is normally executed