### PR TITLE
Fix: Removed wrong isTheoretical check in getNextModel (fixes #61)

### DIFF
--- a/js/BranchingSet.js
+++ b/js/BranchingSet.js
@@ -135,9 +135,7 @@ export default class BranchingSet {
 
     const lastChildModel = branchedModels[branchedModels.length - 1];
     const isLastIncomplete = !lastChildModel.get('_isComplete');
-    if (isLastIncomplete && !isTheoretical) {
-      return false;
-    }
+    if (isLastIncomplete) return false;
 
     const lastChildConfig = lastChildModel.get('_branching');
     if (!lastChildConfig) return true;


### PR DESCRIPTION
fixes #61 

### Fix
*  Removed wrong isTheoretical check in getNextModel, this allows isAtEnd to return false on restored incomplete branching articles and retain _requireCompletionOf at infinity instead of returning it to -1
